### PR TITLE
Milestone 5: Sorting, filtering, and OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,20 +112,44 @@ These are not required. The core assignment is date range + cursor-based paginat
 
 ## Setup & Run Instructions
 
-**Prerequisites:** Java 21 (tested with Eclipse Temurin 21.0.5 LTS)
+**Prerequisites:** Java 21 (tested with Eclipse Temurin 21.0.5 LTS). No Maven install needed — the wrapper (`./mvnw`) downloads it automatically.
+
+### Maven Targets
 
 ```bash
-# Run the server (Maven wrapper included, no install needed)
+# Run the server
 ./mvnw spring-boot:run
 
-# Run all tests
+# Run all tests (unit + integration)
 ./mvnw test
 
-# Build and run via Docker
+# Full build lifecycle: compile, test, package
+./mvnw verify
+
+# Generate Javadoc HTML (output: target/reports/apidocs/index.html)
+./mvnw javadoc:javadoc
+
+# Package as JAR (output: target/events-0.0.1-SNAPSHOT.jar)
+./mvnw package
+
+# Clean build artifacts
+./mvnw clean
+```
+
+### Docker
+
+```bash
 docker build -t events . && docker run -p 8080:8080 events
 ```
 
-The server starts on **port 8080**. Event data is loaded from `sample_data.csv` at startup.
+### What's Running Where
+
+| URL | What |
+|---|---|
+| http://localhost:8080/api/events?start_time=1708646400&end_time=1710028800 | Events endpoint |
+| http://localhost:8080/swagger-ui.html | Interactive API docs (Swagger UI) |
+| http://localhost:8080/v3/api-docs | OpenAPI 3.0 JSON spec |
+| `target/reports/apidocs/index.html` | Generated Javadoc (after `./mvnw javadoc:javadoc`) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -139,12 +139,14 @@ GET /api/events
 
 ### Request Parameters
 
-| Parameter    | Type    | Required | Default | Description                                    |
-|--------------|---------|----------|---------|------------------------------------------------|
-| `start_time` | long    | yes      | —       | Start of date range, inclusive (Unix seconds)  |
-| `end_time`   | long    | yes      | —       | End of date range, inclusive (Unix seconds)    |
-| `limit`      | integer | no       | 20      | Max events per page (clamped to 1–100)         |
-| `cursor`     | string  | no       | —       | Opaque cursor from a previous `next_cursor`    |
+| Parameter          | Type    | Required | Default | Description                                              |
+|--------------------|---------|----------|---------|----------------------------------------------------------|
+| `start_time`       | long    | yes      | —       | Start of date range, inclusive (Unix seconds)             |
+| `end_time`         | long    | yes      | —       | End of date range, inclusive (Unix seconds)               |
+| `limit`            | integer | no       | 20      | Max events per page (clamped to 1–100)                   |
+| `cursor`           | string  | no       | —       | Opaque cursor from a previous `next_cursor`              |
+| `direction`        | string  | no       | `asc`   | Sort direction: `asc` or `desc`                          |
+| `payload_contains` | string  | no       | —       | Case-insensitive substring filter on event payload       |
 
 ### Response Shape
 
@@ -194,6 +196,32 @@ curl "http://localhost:8080/api/events?start_time=1708646400&end_time=1710028800
 |--------|--------------------------------------------|
 | 400    | Missing `start_time` or `end_time`         |
 | 400    | Invalid or malformed `cursor`              |
+| 400    | Invalid `direction` (not `asc` or `desc`)  |
+
+### Interactive API Docs
+
+When the server is running, Swagger UI is available at:
+
+- **Swagger UI:** [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
+- **OpenAPI spec:** [http://localhost:8080/v3/api-docs](http://localhost:8080/v3/api-docs)
+
+### Sorting
+
+Results are sorted by `start_time` with `id` as a stable tie-breaker. Use `direction=desc` to reverse the order. **The cursor must be used with the same sort direction that produced it** — mixing directions with a cursor from a different direction produces undefined results.
+
+```bash
+# Descending: most recent events first
+curl "http://localhost:8080/api/events?start_time=1708646400&end_time=1710028800&limit=5&direction=desc"
+```
+
+### Filtering
+
+Use `payload_contains` to filter events by a substring in their payload (case-insensitive). The filter is applied before pagination, so paginated totals remain consistent with non-paginated totals when the same filter is used.
+
+```bash
+# Only events mentioning "Jazz"
+curl "http://localhost:8080/api/events?start_time=1708646400&end_time=1710028800&payload_contains=Jazz"
+```
 
 ---
 
@@ -305,13 +333,13 @@ io.github.mattmck.events
 
 ## Test Coverage
 
-**32 tests** across 3 test classes:
+**50 tests** across 3 test classes:
 
 | Class                                | Type        | Tests | Covers                                                          |
 |--------------------------------------|-------------|-------|-----------------------------------------------------------------|
 | `CursorCodecTests`                   | Unit        | 8     | Encode/decode round-trips, malformed input, edge cases          |
-| `InMemoryEventStoreTests`            | Unit        | 12    | Dedup, range queries, cursor advancement, pagination walk       |
-| `EventControllerIntegrationTests`    | Integration | 12    | Full HTTP round-trips, pagination contract, error handling      |
+| `InMemoryEventStoreTests`            | Unit        | 21    | Dedup, range queries, cursor advancement, sorting, filtering    |
+| `EventControllerIntegrationTests`    | Integration | 21    | Full HTTP round-trips, pagination, sorting, filtering, errors   |
 
 Key assertions proving pagination correctness:
 - `paginatedTotalMatchesNonPaginatedTotal` — paginating with limit=5 yields 34 unique events, same as a single large request

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.6</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/src/main/java/io/github/mattmck/events/EventsApplication.java
+++ b/src/main/java/io/github/mattmck/events/EventsApplication.java
@@ -12,6 +12,16 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class EventsApplication {
 
+    /** Creates a new application instance. */
+    public EventsApplication() {
+        // default constructor
+    }
+
+    /**
+     * Application entry point. Starts the Spring Boot embedded server.
+     *
+     * @param args command-line arguments
+     */
     public static void main(String[] args) {
         SpringApplication.run(EventsApplication.class, args);
     }

--- a/src/main/java/io/github/mattmck/events/api/EventController.java
+++ b/src/main/java/io/github/mattmck/events/api/EventController.java
@@ -56,7 +56,8 @@ public class EventController {
      * @param endTime   the end of the date range (inclusive, Unix seconds)
      * @param limit     maximum number of events per page (default 20, max 100)
      * @param cursor    opaque cursor from a previous response's {@code next_cursor}
-     * @param direction sort direction: {@code "asc"} (default) or {@code "desc"}
+     * @param direction       sort direction: {@code "asc"} (default) or {@code "desc"}
+     * @param payloadContains optional substring filter on the event payload (case-insensitive)
      * @return a page of events with an optional cursor for the next page
      */
     @GetMapping("/events")
@@ -65,7 +66,8 @@ public class EventController {
             @RequestParam("end_time") Long endTime,
             @RequestParam(value = "limit", required = false) Integer limit,
             @RequestParam(value = "cursor", required = false) String cursor,
-            @RequestParam(value = "direction", required = false, defaultValue = "asc") String direction) {
+            @RequestParam(value = "direction", required = false, defaultValue = "asc") String direction,
+            @RequestParam(value = "payload_contains", required = false) String payloadContains) {
 
         if (startTime == null || endTime == null) {
             return ResponseEntity.badRequest()
@@ -93,7 +95,7 @@ public class EventController {
             }
         }
 
-        var results = eventStore.query(startTime, endTime, effectiveLimit + 1, afterCursor, sortOrder);
+        var results = eventStore.query(startTime, endTime, effectiveLimit + 1, afterCursor, sortOrder, payloadContains);
 
         String nextCursor = null;
         var events = results;

--- a/src/main/java/io/github/mattmck/events/api/EventController.java
+++ b/src/main/java/io/github/mattmck/events/api/EventController.java
@@ -4,6 +4,12 @@ import io.github.mattmck.events.cursor.Cursor;
 import io.github.mattmck.events.cursor.CursorCodec;
 import io.github.mattmck.events.model.Event;
 import io.github.mattmck.events.store.EventStore;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +32,7 @@ import java.util.Map;
  */
 @RestController
 @RequestMapping("/api")
+@Tag(name = "Events", description = "Cursor-based paginated events API")
 public class EventController {
 
     private static final Logger Log = LoggerFactory.getLogger(EventController.class);
@@ -52,21 +59,44 @@ public class EventController {
      * stable tie-breaker. The sort direction defaults to ascending but can be
      * overridden with the {@code direction} parameter.</p>
      *
-     * @param startTime the beginning of the date range (inclusive, Unix seconds)
-     * @param endTime   the end of the date range (inclusive, Unix seconds)
-     * @param limit     maximum number of events per page (default 20, max 100)
-     * @param cursor    opaque cursor from a previous response's {@code next_cursor}
+     * @param startTime       the beginning of the date range (inclusive, Unix seconds)
+     * @param endTime         the end of the date range (inclusive, Unix seconds)
+     * @param limit           maximum number of events per page (default 20, max 100)
+     * @param cursor          opaque cursor from a previous response's {@code next_cursor}
      * @param direction       sort direction: {@code "asc"} (default) or {@code "desc"}
      * @param payloadContains optional substring filter on the event payload (case-insensitive)
      * @return a page of events with an optional cursor for the next page
      */
+    @Operation(
+            summary = "Query events by date range with cursor-based pagination",
+            description = """
+                    Returns events whose start_time falls within [start_time, end_time] inclusive.
+                    Results are paginated using an opaque cursor. Pass next_cursor from a previous
+                    response to fetch the next page. Pagination is complete when next_cursor is null.""",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Page of events",
+                            content = @Content(schema = @Schema(implementation = EventPageResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid parameters or cursor")
+            }
+    )
     @GetMapping("/events")
     public ResponseEntity<?> getEvents(
+            @Parameter(description = "Start of date range (inclusive, Unix seconds)", required = true, example = "1708646400")
             @RequestParam("start_time") Long startTime,
+
+            @Parameter(description = "End of date range (inclusive, Unix seconds)", required = true, example = "1710028800")
             @RequestParam("end_time") Long endTime,
+
+            @Parameter(description = "Max events per page (default 20, max 100)", example = "10")
             @RequestParam(value = "limit", required = false) Integer limit,
+
+            @Parameter(description = "Opaque cursor from a previous next_cursor")
             @RequestParam(value = "cursor", required = false) String cursor,
+
+            @Parameter(description = "Sort direction: asc (default) or desc", example = "asc")
             @RequestParam(value = "direction", required = false, defaultValue = "asc") String direction,
+
+            @Parameter(description = "Case-insensitive substring filter on event payload", example = "Jazz")
             @RequestParam(value = "payload_contains", required = false) String payloadContains) {
 
         if (startTime == null || endTime == null) {

--- a/src/main/java/io/github/mattmck/events/api/EventController.java
+++ b/src/main/java/io/github/mattmck/events/api/EventController.java
@@ -48,13 +48,15 @@ public class EventController {
      * Returns a page of events within the specified date range.
      *
      * <p>Both {@code start_time} and {@code end_time} are inclusive Unix timestamps
-     * in seconds. Results are ordered by {@code start_time} ascending with {@code id}
-     * as a stable tie-breaker.</p>
+     * in seconds. Results are ordered by {@code start_time} with {@code id} as a
+     * stable tie-breaker. The sort direction defaults to ascending but can be
+     * overridden with the {@code direction} parameter.</p>
      *
      * @param startTime the beginning of the date range (inclusive, Unix seconds)
      * @param endTime   the end of the date range (inclusive, Unix seconds)
      * @param limit     maximum number of events per page (default 20, max 100)
      * @param cursor    opaque cursor from a previous response's {@code next_cursor}
+     * @param direction sort direction: {@code "asc"} (default) or {@code "desc"}
      * @return a page of events with an optional cursor for the next page
      */
     @GetMapping("/events")
@@ -62,11 +64,20 @@ public class EventController {
             @RequestParam("start_time") Long startTime,
             @RequestParam("end_time") Long endTime,
             @RequestParam(value = "limit", required = false) Integer limit,
-            @RequestParam(value = "cursor", required = false) String cursor) {
+            @RequestParam(value = "cursor", required = false) String cursor,
+            @RequestParam(value = "direction", required = false, defaultValue = "asc") String direction) {
 
         if (startTime == null || endTime == null) {
             return ResponseEntity.badRequest()
                     .body(Map.of("error", "start_time and end_time are required"));
+        }
+
+        java.util.Comparator<Event> sortOrder;
+        try {
+            sortOrder = Event.comparatorForDirection(direction);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", e.getMessage()));
         }
 
         var effectiveLimit = clampLimit(limit);
@@ -82,7 +93,7 @@ public class EventController {
             }
         }
 
-        var results = eventStore.query(startTime, endTime, effectiveLimit + 1, afterCursor);
+        var results = eventStore.query(startTime, endTime, effectiveLimit + 1, afterCursor, sortOrder);
 
         String nextCursor = null;
         var events = results;

--- a/src/main/java/io/github/mattmck/events/api/EventController.java
+++ b/src/main/java/io/github/mattmck/events/api/EventController.java
@@ -72,7 +72,12 @@ public class EventController {
             description = """
                     Returns events whose start_time falls within [start_time, end_time] inclusive.
                     Results are paginated using an opaque cursor. Pass next_cursor from a previous
-                    response to fetch the next page. Pagination is complete when next_cursor is null.""",
+                    response to fetch the next page. Pagination is complete when next_cursor is null.
+
+                    Important: a cursor is only valid when reused with the same query parameters
+                    that produced it (start_time, end_time, direction, payload_contains). Changing
+                    any of these between pages alters the result stream and may cause the cursor
+                    to resume from an incorrect position.""",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Page of events",
                             content = @Content(schema = @Schema(implementation = EventPageResponse.class))),
@@ -90,7 +95,7 @@ public class EventController {
             @Parameter(description = "Max events per page (default 20, max 100)", example = "10")
             @RequestParam(value = "limit", required = false) Integer limit,
 
-            @Parameter(description = "Opaque cursor from a previous next_cursor")
+            @Parameter(description = "Opaque cursor from a previous next_cursor. Only valid with the same start_time, end_time, direction, and payload_contains that produced it.")
             @RequestParam(value = "cursor", required = false) String cursor,
 
             @Parameter(description = "Sort direction: asc (default) or desc", example = "asc")

--- a/src/main/java/io/github/mattmck/events/config/CsvDataConfig.java
+++ b/src/main/java/io/github/mattmck/events/config/CsvDataConfig.java
@@ -33,6 +33,11 @@ import static java.util.Comparator.comparingInt;
 @Configuration
 public class CsvDataConfig {
 
+    /** Creates a new configuration instance. */
+    public CsvDataConfig() {
+        // default constructor
+    }
+
     private static final Logger Log = LoggerFactory.getLogger(CsvDataConfig.class);
 
     /**

--- a/src/main/java/io/github/mattmck/events/model/Event.java
+++ b/src/main/java/io/github/mattmck/events/model/Event.java
@@ -1,6 +1,7 @@
 package io.github.mattmck.events.model;
 
 import java.util.Comparator;
+import java.util.Locale;
 
 /**
  * A deduplicated event ready for API responses.
@@ -42,7 +43,7 @@ public record Event(long startTime, String id, String payload) implements Compar
         if (direction == null) {
             return START_TIME_ASC;
         }
-        return switch (direction.toLowerCase()) {
+        return switch (direction.toLowerCase(Locale.ROOT)) {
             case "asc" -> START_TIME_ASC;
             case "desc" -> START_TIME_DESC;
             default -> throw new IllegalArgumentException(

--- a/src/main/java/io/github/mattmck/events/model/Event.java
+++ b/src/main/java/io/github/mattmck/events/model/Event.java
@@ -39,6 +39,9 @@ public record Event(long startTime, String id, String payload) implements Compar
      * @throws IllegalArgumentException if direction is not {@code "asc"} or {@code "desc"}
      */
     public static Comparator<Event> comparatorForDirection(String direction) {
+        if (direction == null) {
+            return START_TIME_ASC;
+        }
         return switch (direction.toLowerCase()) {
             case "asc" -> START_TIME_ASC;
             case "desc" -> START_TIME_DESC;

--- a/src/main/java/io/github/mattmck/events/model/Event.java
+++ b/src/main/java/io/github/mattmck/events/model/Event.java
@@ -18,9 +18,34 @@ import java.util.Comparator;
  */
 public record Event(long startTime, String id, String payload) implements Comparable<Event> {
 
-    /** Comparator defining the canonical sort order: startTime ascending, then id ascending. */
-    public static final Comparator<Event> SORT_ORDER =
+    /** Comparator: startTime ascending, then id ascending (default). */
+    public static final Comparator<Event> START_TIME_ASC =
             Comparator.comparingLong(Event::startTime).thenComparing(Event::id);
+
+    /** Comparator: startTime descending, then id descending. */
+    public static final Comparator<Event> START_TIME_DESC =
+            START_TIME_ASC.reversed();
+
+    /**
+     * Default sort order used for natural ordering ({@link #START_TIME_ASC}).
+     */
+    public static final Comparator<Event> SORT_ORDER = START_TIME_ASC;
+
+    /**
+     * Returns the appropriate comparator for the given direction.
+     *
+     * @param direction {@code "asc"} or {@code "desc"} (case-insensitive)
+     * @return the corresponding comparator
+     * @throws IllegalArgumentException if direction is not {@code "asc"} or {@code "desc"}
+     */
+    public static Comparator<Event> comparatorForDirection(String direction) {
+        return switch (direction.toLowerCase()) {
+            case "asc" -> START_TIME_ASC;
+            case "desc" -> START_TIME_DESC;
+            default -> throw new IllegalArgumentException(
+                    "Invalid direction: " + direction + ". Must be 'asc' or 'desc'.");
+        };
+    }
 
     @Override
     public int compareTo(Event other) {

--- a/src/main/java/io/github/mattmck/events/model/Event.java
+++ b/src/main/java/io/github/mattmck/events/model/Event.java
@@ -35,9 +35,9 @@ public record Event(long startTime, String id, String payload) implements Compar
     /**
      * Returns the appropriate comparator for the given direction.
      *
-     * @param direction {@code "asc"} or {@code "desc"} (case-insensitive)
+     * @param direction {@code "asc"}, {@code "desc"} (case-insensitive), or {@code null} (defaults to ascending)
      * @return the corresponding comparator
-     * @throws IllegalArgumentException if direction is not {@code "asc"} or {@code "desc"}
+     * @throws IllegalArgumentException if direction is non-null and not {@code "asc"} or {@code "desc"}
      */
     public static Comparator<Event> comparatorForDirection(String direction) {
         if (direction == null) {

--- a/src/main/java/io/github/mattmck/events/store/EventStore.java
+++ b/src/main/java/io/github/mattmck/events/store/EventStore.java
@@ -46,6 +46,30 @@ public interface EventStore {
      * @param sortOrder   comparator defining the result ordering
      * @return an unmodifiable list of matching events in the specified order
      */
+    default List<Event> query(long rangeStart, long rangeEnd, int maxResults, Cursor afterCursor,
+                      Comparator<Event> sortOrder) {
+        return query(rangeStart, rangeEnd, maxResults, afterCursor, sortOrder, null);
+    }
+
+    /**
+     * Returns up to {@code maxResults} events whose {@code startTime} falls within
+     * the inclusive range {@code [rangeStart, rangeEnd]}, in the order defined by
+     * {@code sortOrder}, optionally filtered by a payload substring.
+     *
+     * <p>If {@code payloadContains} is non-null and non-blank, only events whose payload
+     * contains the substring (case-insensitive) are included. The filter is applied before
+     * pagination, so paginated totals remain consistent with non-paginated totals when
+     * the same filter is used.</p>
+     *
+     * @param rangeStart      minimum startTime (inclusive), as a Unix timestamp in seconds
+     * @param rangeEnd        maximum startTime (inclusive), as a Unix timestamp in seconds
+     * @param maxResults      maximum number of events to return
+     * @param afterCursor     if non-null, skip all events at or before this cursor position
+     * @param sortOrder       comparator defining the result ordering
+     * @param payloadContains if non-null, filter events to those whose payload contains
+     *                        this substring (case-insensitive)
+     * @return an unmodifiable list of matching events in the specified order
+     */
     List<Event> query(long rangeStart, long rangeEnd, int maxResults, Cursor afterCursor,
-                      Comparator<Event> sortOrder);
+                      Comparator<Event> sortOrder, String payloadContains);
 }

--- a/src/main/java/io/github/mattmck/events/store/EventStore.java
+++ b/src/main/java/io/github/mattmck/events/store/EventStore.java
@@ -11,6 +11,11 @@ import java.util.List;
  *
  * <p>Implementations return events in the order specified by the caller. When no
  * explicit ordering is given, the default is {@link Event#START_TIME_ASC}.</p>
+ *
+ * <p><strong>Supported sort orders:</strong> Only {@link Event#START_TIME_ASC} and
+ * {@link Event#START_TIME_DESC} are supported. Passing a different comparator
+ * produces undefined results because implementations may rely on pre-sorted lists
+ * that match these specific orderings.</p>
  */
 public interface EventStore {
 

--- a/src/main/java/io/github/mattmck/events/store/EventStore.java
+++ b/src/main/java/io/github/mattmck/events/store/EventStore.java
@@ -3,28 +3,49 @@ package io.github.mattmck.events.store;
 import io.github.mattmck.events.cursor.Cursor;
 import io.github.mattmck.events.model.Event;
 
+import java.util.Comparator;
 import java.util.List;
 
 /**
  * Read-only store for querying deduplicated events within a date range.
  *
- * <p>Implementations are expected to return events sorted by
- * {@link Event#SORT_ORDER} (startTime ascending, then id ascending).</p>
+ * <p>Implementations return events in the order specified by the caller. When no
+ * explicit ordering is given, the default is {@link Event#START_TIME_ASC}.</p>
  */
 public interface EventStore {
 
     /**
      * Returns up to {@code maxResults} events whose {@code startTime} falls within
-     * the inclusive range {@code [rangeStart, rangeEnd]}.
+     * the inclusive range {@code [rangeStart, rangeEnd]}, using the default sort order
+     * ({@link Event#START_TIME_ASC}).
      *
-     * <p>If {@code afterCursor} is non-null, only events positioned strictly after the
-     * cursor in sort order are returned. This enables cursor-based pagination.</p>
-     *
-     * @param rangeStart minimum startTime (inclusive), as a Unix timestamp in seconds
-     * @param rangeEnd   maximum startTime (inclusive), as a Unix timestamp in seconds
-     * @param maxResults maximum number of events to return
+     * @param rangeStart  minimum startTime (inclusive), as a Unix timestamp in seconds
+     * @param rangeEnd    maximum startTime (inclusive), as a Unix timestamp in seconds
+     * @param maxResults  maximum number of events to return
      * @param afterCursor if non-null, skip all events at or before this cursor position
      * @return an unmodifiable list of matching events in sort order
      */
-    List<Event> query(long rangeStart, long rangeEnd, int maxResults, Cursor afterCursor);
+    default List<Event> query(long rangeStart, long rangeEnd, int maxResults, Cursor afterCursor) {
+        return query(rangeStart, rangeEnd, maxResults, afterCursor, Event.START_TIME_ASC);
+    }
+
+    /**
+     * Returns up to {@code maxResults} events whose {@code startTime} falls within
+     * the inclusive range {@code [rangeStart, rangeEnd]}, in the order defined by
+     * {@code sortOrder}.
+     *
+     * <p>If {@code afterCursor} is non-null, only events positioned strictly after the
+     * cursor in the given sort order are returned. The cursor must have been derived
+     * from the same sort order — mixing cursors across different orderings produces
+     * undefined results.</p>
+     *
+     * @param rangeStart  minimum startTime (inclusive), as a Unix timestamp in seconds
+     * @param rangeEnd    maximum startTime (inclusive), as a Unix timestamp in seconds
+     * @param maxResults  maximum number of events to return
+     * @param afterCursor if non-null, skip all events at or before this cursor position
+     * @param sortOrder   comparator defining the result ordering
+     * @return an unmodifiable list of matching events in the specified order
+     */
+    List<Event> query(long rangeStart, long rangeEnd, int maxResults, Cursor afterCursor,
+                      Comparator<Event> sortOrder);
 }

--- a/src/main/java/io/github/mattmck/events/store/InMemoryEventStore.java
+++ b/src/main/java/io/github/mattmck/events/store/InMemoryEventStore.java
@@ -22,7 +22,7 @@ import java.util.List;
  * how a database materialized view works: the raw rows are the source of truth, and this
  * store provides fast, consistent reads over the clean data.</p>
  *
- * <h3>How cursor lookup works</h3>
+ * <p><strong>How cursor lookup works:</strong></p>
  *
  * <p>{@link Event} implements {@link Comparable} with natural ordering by
  * {@code (startTime, id)}. This lets us use {@link java.util.Collections#binarySearch}
@@ -35,14 +35,14 @@ import java.util.List;
  * {@code binarySearch} returns the insertion point, which is already the first element
  * greater than the cursor. This gives us O(log n) cursor resolution.</p>
  *
- * <h3>Sort order support</h3>
+ * <p><strong>Sort order support:</strong></p>
  *
  * <p>The store maintains the canonical ascending list and creates a reversed view on
  * demand for descending queries. Binary search and range filtering adapt to the
  * requested comparator, so cursors remain correct regardless of direction — as long
  * as the cursor was derived from the same sort order.</p>
  *
- * <h3>Future: database-backed implementation</h3>
+ * <p><strong>Future: database-backed implementation:</strong></p>
  *
  * <p>A database-backed {@link EventStore} would replace the binary search with a SQL
  * query using a composite {@code WHERE} clause:</p>

--- a/src/main/java/io/github/mattmck/events/store/InMemoryEventStore.java
+++ b/src/main/java/io/github/mattmck/events/store/InMemoryEventStore.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -34,6 +35,13 @@ import java.util.List;
  * {@code binarySearch} returns the insertion point, which is already the first element
  * greater than the cursor. This gives us O(log n) cursor resolution.</p>
  *
+ * <h3>Sort order support</h3>
+ *
+ * <p>The store maintains the canonical ascending list and creates a reversed view on
+ * demand for descending queries. Binary search and range filtering adapt to the
+ * requested comparator, so cursors remain correct regardless of direction — as long
+ * as the cursor was derived from the same sort order.</p>
+ *
  * <h3>Future: database-backed implementation</h3>
  *
  * <p>A database-backed {@link EventStore} would replace the binary search with a SQL
@@ -51,32 +59,40 @@ public class InMemoryEventStore implements EventStore {
 
     private static final Logger Log = LoggerFactory.getLogger(InMemoryEventStore.class);
 
-    private final List<Event> sortedEvents;
+    private final List<Event> ascendingEvents;
+    private final List<Event> descendingEvents;
 
     /**
      * Creates a new store from a pre-sorted, deduplicated list of events.
      *
-     * @param sortedEvents events sorted by {@link Event#SORT_ORDER}; must not contain
+     * @param sortedEvents events sorted by {@link Event#START_TIME_ASC}; must not contain
      *                     duplicate IDs
      */
     public InMemoryEventStore(List<Event> sortedEvents) {
-        this.sortedEvents = List.copyOf(sortedEvents);
-        Log.info("Initialized InMemoryEventStore with {} events", this.sortedEvents.size());
+        this.ascendingEvents = List.copyOf(sortedEvents);
+        var reversed = new ArrayList<>(sortedEvents);
+        Collections.reverse(reversed);
+        this.descendingEvents = List.copyOf(reversed);
+        Log.info("Initialized InMemoryEventStore with {} events", this.ascendingEvents.size());
     }
 
     @Override
-    public List<Event> query(long rangeStart, long rangeEnd, int maxResults, Cursor afterCursor) {
+    public List<Event> query(long rangeStart, long rangeEnd, int maxResults, Cursor afterCursor,
+                             Comparator<Event> sortOrder) {
         if (rangeStart > rangeEnd || maxResults <= 0) {
             return List.of();
         }
 
-        var startIndex = findStartIndex(rangeStart, afterCursor);
-        var results = new ArrayList<Event>(Math.min(maxResults, sortedEvents.size()));
+        var isDescending = sortOrder == Event.START_TIME_DESC;
+        var events = isDescending ? descendingEvents : ascendingEvents;
 
-        for (var i = startIndex; i < sortedEvents.size() && results.size() < maxResults; i++) {
-            var event = sortedEvents.get(i);
+        var startIndex = findStartIndex(events, sortOrder, rangeStart, rangeEnd, afterCursor);
+        var results = new ArrayList<Event>(Math.min(maxResults, events.size()));
 
-            if (event.startTime() > rangeEnd) {
+        for (var i = startIndex; i < events.size() && results.size() < maxResults; i++) {
+            var event = events.get(i);
+
+            if (!isInRange(event, rangeStart, rangeEnd)) {
                 break;
             }
 
@@ -92,48 +108,78 @@ public class InMemoryEventStore implements EventStore {
      * @return the event count
      */
     public int size() {
-        return sortedEvents.size();
+        return ascendingEvents.size();
+    }
+
+    /**
+     * Checks whether an event falls within the time range. For ascending order,
+     * we break when we exceed rangeEnd. For descending, we break when we go below
+     * rangeStart.
+     */
+    private boolean isInRange(Event event, long rangeStart, long rangeEnd) {
+        return event.startTime() >= rangeStart && event.startTime() <= rangeEnd;
     }
 
     /**
      * Finds the index of the first event to include in results, using binary search.
      *
      * <p>If a cursor is provided, finds the first event strictly after the cursor position
-     * in sort order. Otherwise, finds the first event at or after {@code rangeStart}.</p>
+     * in the given sort order. Otherwise, finds the first event at or after the range
+     * boundary appropriate for the sort direction.</p>
      */
-    private int findStartIndex(long rangeStart, Cursor afterCursor) {
+    private int findStartIndex(List<Event> events, Comparator<Event> sortOrder,
+                               long rangeStart, long rangeEnd, Cursor afterCursor) {
         if (afterCursor != null) {
-            return findFirstIndexAfter(afterCursor.startTime(), afterCursor.id());
+            return findFirstIndexAfter(events, sortOrder, afterCursor.startTime(), afterCursor.id());
         }
-        return findFirstIndexAtOrAfter(rangeStart);
+        // For ascending, start at the first event >= rangeStart
+        // For descending, start at the first event <= rangeEnd (which is the beginning of the desc list in range)
+        var isDescending = sortOrder == Event.START_TIME_DESC;
+        if (isDescending) {
+            return findFirstDescendingInRange(events, rangeEnd);
+        }
+        return findFirstAscendingInRange(events, rangeStart);
     }
 
     /**
-     * Binary search for the first event with {@code startTime >= target}.
+     * Binary search for the first event with {@code startTime >= target} in ascending list.
      */
-    private int findFirstIndexAtOrAfter(long targetTime) {
+    private int findFirstAscendingInRange(List<Event> events, long targetTime) {
         var searchKey = new Event(targetTime, "", "");
-        var index = Collections.binarySearch(sortedEvents, searchKey);
-        // binarySearch returns (-(insertion point) - 1) when key is not found
+        var index = Collections.binarySearch(events, searchKey, Event.START_TIME_ASC);
         return index >= 0 ? index : -(index + 1);
     }
 
     /**
-     * Binary search for the first event strictly after {@code (targetTime, targetId)}
-     * in sort order.
+     * Binary search for the first event with {@code startTime <= target} in descending list.
+     * In descending order, the list goes from highest to lowest startTime.
+     * We need the first element where startTime <= rangeEnd.
      */
-    private int findFirstIndexAfter(long targetTime, String targetId) {
-        // Search for an event matching the cursor position
+    private int findFirstDescendingInRange(List<Event> events, long rangeEnd) {
+        // In descending list, find first event where startTime <= rangeEnd
+        for (var i = 0; i < events.size(); i++) {
+            if (events.get(i).startTime() <= rangeEnd) {
+                return i;
+            }
+        }
+        return events.size();
+    }
+
+    /**
+     * Binary search for the first event strictly after {@code (targetTime, targetId)}
+     * in the given sort order.
+     */
+    private int findFirstIndexAfter(List<Event> events, Comparator<Event> sortOrder,
+                                    long targetTime, String targetId) {
         var searchKey = new Event(targetTime, targetId, "");
-        var index = Collections.binarySearch(sortedEvents, searchKey);
+        var index = Collections.binarySearch(events, searchKey, sortOrder);
 
         if (index >= 0) {
             // Exact match found — return the next position
             return index + 1;
         }
 
-        // Not found — insertion point is where the cursor would be, which is also
-        // the first element strictly greater than the cursor
+        // Not found — insertion point is the first element strictly greater in sort order
         return -(index + 1);
     }
 }

--- a/src/main/java/io/github/mattmck/events/store/InMemoryEventStore.java
+++ b/src/main/java/io/github/mattmck/events/store/InMemoryEventStore.java
@@ -78,13 +78,16 @@ public class InMemoryEventStore implements EventStore {
 
     @Override
     public List<Event> query(long rangeStart, long rangeEnd, int maxResults, Cursor afterCursor,
-                             Comparator<Event> sortOrder) {
+                             Comparator<Event> sortOrder, String payloadContains) {
         if (rangeStart > rangeEnd || maxResults <= 0) {
             return List.of();
         }
 
         var isDescending = sortOrder == Event.START_TIME_DESC;
         var events = isDescending ? descendingEvents : ascendingEvents;
+        var filterLower = (payloadContains != null && !payloadContains.isBlank())
+                ? payloadContains.toLowerCase()
+                : null;
 
         var startIndex = findStartIndex(events, sortOrder, rangeStart, rangeEnd, afterCursor);
         var results = new ArrayList<Event>(Math.min(maxResults, events.size()));
@@ -94,6 +97,10 @@ public class InMemoryEventStore implements EventStore {
 
             if (!isInRange(event, rangeStart, rangeEnd)) {
                 break;
+            }
+
+            if (filterLower != null && !event.payload().toLowerCase().contains(filterLower)) {
+                continue;
             }
 
             results.add(event);

--- a/src/main/java/io/github/mattmck/events/store/InMemoryEventStore.java
+++ b/src/main/java/io/github/mattmck/events/store/InMemoryEventStore.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * In-memory implementation of {@link EventStore} backed by a pre-sorted list of
@@ -37,8 +38,8 @@ import java.util.List;
  *
  * <p><strong>Sort order support:</strong></p>
  *
- * <p>The store maintains the canonical ascending list and creates a reversed view on
- * demand for descending queries. Binary search and range filtering adapt to the
+ * <p>The store maintains the canonical ascending list and an eagerly materialized
+ * reversed list for descending queries. Binary search and range filtering adapt to the
  * requested comparator, so cursors remain correct regardless of direction — as long
  * as the cursor was derived from the same sort order.</p>
  *
@@ -86,7 +87,7 @@ public class InMemoryEventStore implements EventStore {
         var isDescending = sortOrder.equals(Event.START_TIME_DESC);
         var events = isDescending ? descendingEvents : ascendingEvents;
         var filterLower = (payloadContains != null && !payloadContains.isBlank())
-                ? payloadContains.toLowerCase()
+                ? payloadContains.toLowerCase(Locale.ROOT)
                 : null;
 
         var startIndex = findStartIndex(events, sortOrder, rangeStart, rangeEnd, afterCursor);
@@ -96,11 +97,16 @@ public class InMemoryEventStore implements EventStore {
             var event = events.get(i);
 
             if (!isInRange(event, rangeStart, rangeEnd)) {
+                if (isDescending ? event.startTime() > rangeEnd : event.startTime() < rangeStart) {
+                    // Cursor landed before the range boundary — skip until we reach the range
+                    continue;
+                }
+                // Past the far end of the range — no more matches possible
                 break;
             }
 
             if (filterLower != null
-                    && (event.payload() == null || !event.payload().toLowerCase().contains(filterLower))) {
+                    && (event.payload() == null || !event.payload().toLowerCase(Locale.ROOT).contains(filterLower))) {
                 continue;
             }
 

--- a/src/main/java/io/github/mattmck/events/store/InMemoryEventStore.java
+++ b/src/main/java/io/github/mattmck/events/store/InMemoryEventStore.java
@@ -83,7 +83,7 @@ public class InMemoryEventStore implements EventStore {
             return List.of();
         }
 
-        var isDescending = sortOrder == Event.START_TIME_DESC;
+        var isDescending = sortOrder.equals(Event.START_TIME_DESC);
         var events = isDescending ? descendingEvents : ascendingEvents;
         var filterLower = (payloadContains != null && !payloadContains.isBlank())
                 ? payloadContains.toLowerCase()
@@ -99,7 +99,8 @@ public class InMemoryEventStore implements EventStore {
                 break;
             }
 
-            if (filterLower != null && !event.payload().toLowerCase().contains(filterLower)) {
+            if (filterLower != null
+                    && (event.payload() == null || !event.payload().toLowerCase().contains(filterLower))) {
                 continue;
             }
 
@@ -141,7 +142,7 @@ public class InMemoryEventStore implements EventStore {
         }
         // For ascending, start at the first event >= rangeStart
         // For descending, start at the first event <= rangeEnd (which is the beginning of the desc list in range)
-        var isDescending = sortOrder == Event.START_TIME_DESC;
+        var isDescending = sortOrder.equals(Event.START_TIME_DESC);
         if (isDescending) {
             return findFirstDescendingInRange(events, rangeEnd);
         }
@@ -159,17 +160,23 @@ public class InMemoryEventStore implements EventStore {
 
     /**
      * Binary search for the first event with {@code startTime <= target} in descending list.
-     * In descending order, the list goes from highest to lowest startTime.
-     * We need the first element where startTime <= rangeEnd.
+     *
+     * <p>In descending order, the list goes from highest to lowest startTime. We need the
+     * first index where {@code startTime <= rangeEnd}. This is equivalent to finding the
+     * leftmost position where the condition holds, which binary search resolves in O(log n).</p>
      */
     private int findFirstDescendingInRange(List<Event> events, long rangeEnd) {
-        // In descending list, find first event where startTime <= rangeEnd
-        for (var i = 0; i < events.size(); i++) {
-            if (events.get(i).startTime() <= rangeEnd) {
-                return i;
+        var low = 0;
+        var high = events.size();
+        while (low < high) {
+            var mid = low + (high - low) / 2;
+            if (events.get(mid).startTime() > rangeEnd) {
+                low = mid + 1;
+            } else {
+                high = mid;
             }
         }
-        return events.size();
+        return low;
     }
 
     /**

--- a/src/test/java/io/github/mattmck/events/api/EventControllerIntegrationTests.java
+++ b/src/test/java/io/github/mattmck/events/api/EventControllerIntegrationTests.java
@@ -171,21 +171,98 @@ class EventControllerIntegrationTests {
         }
     }
 
+    // --- Sorting tests ---
+
+    @Test
+    @DisplayName("direction=desc returns events in descending order")
+    void descDirectionReturnsDescendingOrder() {
+        var response = webClient.get()
+                .uri("/api/events?start_time={s}&end_time={e}&limit=100&direction=desc",
+                        DATA_START, DATA_END)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(EventPageResponse.class)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(response).isNotNull();
+        assertThat(response.events()).hasSize(TOTAL_UNIQUE_EVENTS);
+
+        // Verify descending order: each event's startTime >= next event's startTime
+        var events = response.events();
+        for (var i = 0; i < events.size() - 1; i++) {
+            assertThat(events.get(i).startTime())
+                    .isGreaterThanOrEqualTo(events.get(i + 1).startTime());
+        }
+    }
+
+    @Test
+    @DisplayName("descending pagination produces same IDs as ascending")
+    void descendingPaginationMatchesAscending() {
+        var ascIds = collectAllPaginatedIds(5, "asc");
+        var descIds = collectAllPaginatedIds(5, "desc");
+
+        assertThat(new HashSet<>(descIds))
+                .as("Descending pagination should cover the same events as ascending")
+                .isEqualTo(new HashSet<>(ascIds));
+    }
+
+    @Test
+    @DisplayName("descending pagination has no duplicates across pages")
+    void descendingPaginationNoDuplicates() {
+        var ids = collectAllPaginatedIds(5, "desc");
+
+        assertThat(ids)
+                .hasSize(TOTAL_UNIQUE_EVENTS)
+                .doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("descending pagination works with various limit sizes")
+    void descendingPaginationWorksWithVariousLimits() {
+        for (var limit : List.of(1, 3, 7, 10, 17, 34)) {
+            var ids = collectAllPaginatedIds(limit, "desc");
+
+            assertThat(ids)
+                    .as("desc limit=%d should produce %d unique events", limit, TOTAL_UNIQUE_EVENTS)
+                    .hasSize(TOTAL_UNIQUE_EVENTS)
+                    .doesNotHaveDuplicates();
+        }
+    }
+
+    @Test
+    @DisplayName("invalid direction returns 400")
+    void invalidDirectionReturns400() {
+        webClient.get()
+                .uri("/api/events?start_time={s}&end_time={e}&direction=sideways",
+                        DATA_START, DATA_END)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
     /**
      * Walks through all pages using the given limit and collects every event ID
-     * encountered across all pages.
+     * encountered across all pages. Uses ascending sort direction.
      */
     private List<String> collectAllPaginatedIds(int limit) {
+        return collectAllPaginatedIds(limit, "asc");
+    }
+
+    /**
+     * Walks through all pages using the given limit and sort direction, collecting
+     * every event ID encountered across all pages.
+     */
+    private List<String> collectAllPaginatedIds(int limit, String direction) {
         var allIds = new ArrayList<String>();
         String cursor = null;
         var maxPages = (TOTAL_UNIQUE_EVENTS / limit) + 2; // safety cap
 
         for (var page = 0; page < maxPages; page++) {
             var uri = cursor == null
-                    ? "/api/events?start_time=%d&end_time=%d&limit=%d"
-                            .formatted(DATA_START, DATA_END, limit)
-                    : "/api/events?start_time=%d&end_time=%d&limit=%d&cursor=%s"
-                            .formatted(DATA_START, DATA_END, limit, cursor);
+                    ? "/api/events?start_time=%d&end_time=%d&limit=%d&direction=%s"
+                            .formatted(DATA_START, DATA_END, limit, direction)
+                    : "/api/events?start_time=%d&end_time=%d&limit=%d&direction=%s&cursor=%s"
+                            .formatted(DATA_START, DATA_END, limit, direction, cursor);
 
             var response = webClient.get()
                     .uri(uri)

--- a/src/test/java/io/github/mattmck/events/api/EventControllerIntegrationTests.java
+++ b/src/test/java/io/github/mattmck/events/api/EventControllerIntegrationTests.java
@@ -230,6 +230,72 @@ class EventControllerIntegrationTests {
         }
     }
 
+    // --- Filter tests ---
+
+    @Test
+    @DisplayName("payload_contains filters events by substring")
+    void payloadContainsFiltersEvents() {
+        var response = webClient.get()
+                .uri("/api/events?start_time={s}&end_time={e}&limit=100&payload_contains=Jazz",
+                        DATA_START, DATA_END)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(EventPageResponse.class)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(response).isNotNull();
+        assertThat(response.events()).isNotEmpty();
+        assertThat(response.events())
+                .allSatisfy(event ->
+                        assertThat(event.payload().toLowerCase()).contains("jazz"));
+    }
+
+    @Test
+    @DisplayName("filtered paginated totals match filtered non-paginated totals")
+    void filteredPaginatedTotalsMatch() {
+        // Get all filtered events in one shot
+        var allAtOnce = webClient.get()
+                .uri("/api/events?start_time={s}&end_time={e}&limit=100&payload_contains=Night",
+                        DATA_START, DATA_END)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(EventPageResponse.class)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(allAtOnce).isNotNull();
+        var expectedCount = allAtOnce.events().size();
+
+        // Now paginate with the same filter
+        var paginatedIds = collectAllFilteredPaginatedIds(2, "Night");
+
+        assertThat(paginatedIds)
+                .hasSize(expectedCount)
+                .doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("filtered pagination has no duplicates across pages")
+    void filteredPaginationNoDuplicates() {
+        var ids = collectAllFilteredPaginatedIds(2, "Night");
+
+        assertThat(ids).doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("payload_contains with no matches returns empty")
+    void payloadContainsNoMatchesReturnsEmpty() {
+        webClient.get()
+                .uri("/api/events?start_time={s}&end_time={e}&payload_contains=zzz-no-match",
+                        DATA_START, DATA_END)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.events.length()").isEqualTo(0)
+                .jsonPath("$.next_cursor").isEqualTo(null);
+    }
+
     @Test
     @DisplayName("invalid direction returns 400")
     void invalidDirectionReturns400() {
@@ -246,6 +312,45 @@ class EventControllerIntegrationTests {
      */
     private List<String> collectAllPaginatedIds(int limit) {
         return collectAllPaginatedIds(limit, "asc");
+    }
+
+    /**
+     * Walks through all pages with a payload filter, collecting every event ID.
+     */
+    private List<String> collectAllFilteredPaginatedIds(int limit, String payloadContains) {
+        var allIds = new ArrayList<String>();
+        String cursor = null;
+        var maxPages = TOTAL_UNIQUE_EVENTS + 2;
+
+        for (var page = 0; page < maxPages; page++) {
+            var uri = cursor == null
+                    ? "/api/events?start_time=%d&end_time=%d&limit=%d&payload_contains=%s"
+                            .formatted(DATA_START, DATA_END, limit, payloadContains)
+                    : "/api/events?start_time=%d&end_time=%d&limit=%d&payload_contains=%s&cursor=%s"
+                            .formatted(DATA_START, DATA_END, limit, payloadContains, cursor);
+
+            var response = webClient.get()
+                    .uri(uri)
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectBody(EventPageResponse.class)
+                    .returnResult()
+                    .getResponseBody();
+
+            assertThat(response).isNotNull();
+            assertThat(response.events().size()).isLessThanOrEqualTo(limit);
+
+            for (var event : response.events()) {
+                allIds.add(event.id());
+            }
+
+            cursor = response.nextCursor();
+            if (cursor == null) {
+                break;
+            }
+        }
+
+        return allIds;
     }
 
     /**

--- a/src/test/java/io/github/mattmck/events/store/InMemoryEventStoreTests.java
+++ b/src/test/java/io/github/mattmck/events/store/InMemoryEventStoreTests.java
@@ -262,4 +262,75 @@ class InMemoryEventStoreTests {
                 .hasSize(3)
                 .allSatisfy(event -> assertThat(event.startTime()).isEqualTo(T2));
     }
+
+    // --- Payload filter tests ---
+
+    @Test
+    @DisplayName("payload filter returns only matching events")
+    void payloadFilterReturnsMatches() {
+        var results = store.query(T1, T3, 100, null, Event.START_TIME_ASC, "alpha");
+
+        assertThat(results)
+                .hasSize(1)
+                .allSatisfy(event ->
+                        assertThat(event.payload().toLowerCase()).contains("alpha"));
+    }
+
+    @Test
+    @DisplayName("payload filter is case-insensitive")
+    void payloadFilterIsCaseInsensitive() {
+        var lower = store.query(T1, T3, 100, null, Event.START_TIME_ASC, "echo");
+        var upper = store.query(T1, T3, 100, null, Event.START_TIME_ASC, "ECHO");
+        var mixed = store.query(T1, T3, 100, null, Event.START_TIME_ASC, "Echo");
+
+        assertThat(lower).isEqualTo(upper).isEqualTo(mixed);
+    }
+
+    @Test
+    @DisplayName("payload filter with no matches returns empty list")
+    void payloadFilterNoMatchesReturnsEmpty() {
+        var results = store.query(T1, T3, 100, null, Event.START_TIME_ASC, "zzz-no-match");
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("null payload filter returns all events (no filtering)")
+    void nullPayloadFilterReturnsAll() {
+        var results = store.query(T1, T3, 100, null, Event.START_TIME_ASC, null);
+
+        assertThat(results).hasSize(7);
+    }
+
+    @Test
+    @DisplayName("filtered pagination covers all matching events exactly once")
+    void filteredPaginationCoversAllMatchingEvents() {
+        // "o" appears in: Bravo, Foxtrot, Golf = 3 events
+        var limit = 1;
+        var allIds = new ArrayList<String>();
+        Cursor cursor = null;
+
+        while (true) {
+            var results = store.query(T1, T3, limit + 1, cursor, Event.START_TIME_ASC, "o");
+            var page = results.size() > limit
+                    ? results.subList(0, limit)
+                    : results;
+
+            allIds.addAll(page.stream().map(Event::id).toList());
+
+            if (results.size() <= limit) {
+                break;
+            }
+
+            var lastEvent = page.getLast();
+            cursor = new Cursor(lastEvent.startTime(), lastEvent.id());
+        }
+
+        assertThat(allIds).doesNotHaveDuplicates();
+        assertThat(allIds).allSatisfy(id -> {
+            var event = store.query(T1, T3, 100, null, Event.START_TIME_ASC, null)
+                    .stream().filter(e -> e.id().equals(id)).findFirst().orElseThrow();
+            assertThat(event.payload().toLowerCase()).contains("o");
+        });
+    }
 }

--- a/src/test/java/io/github/mattmck/events/store/InMemoryEventStoreTests.java
+++ b/src/test/java/io/github/mattmck/events/store/InMemoryEventStoreTests.java
@@ -186,4 +186,80 @@ class InMemoryEventStoreTests {
                 .containsExactlyInAnyOrder(
                         "evt-a", "evt-b", "evt-c", "evt-d", "evt-e", "evt-f", "evt-g");
     }
+
+    // --- Descending sort order tests ---
+
+    @Test
+    @DisplayName("descending query returns events in reverse order")
+    void descendingQueryReturnsReverseOrder() {
+        var results = store.query(T1, T3, 100, null, Event.START_TIME_DESC);
+
+        assertThat(results)
+                .hasSize(7)
+                .isSortedAccordingTo(Event.START_TIME_DESC);
+
+        // First event should be from T3, last from T1
+        assertThat(results.getFirst().startTime()).isEqualTo(T3);
+        assertThat(results.getLast().startTime()).isEqualTo(T1);
+    }
+
+    @Test
+    @DisplayName("descending pagination covers every event exactly once")
+    void descendingFullPaginationCoversAllEvents() {
+        var limit = 2;
+        var allIds = new ArrayList<String>();
+        Cursor cursor = null;
+
+        while (true) {
+            var results = store.query(T1, T3, limit + 1, cursor, Event.START_TIME_DESC);
+            var page = results.size() > limit
+                    ? results.subList(0, limit)
+                    : results;
+
+            allIds.addAll(page.stream().map(Event::id).toList());
+
+            if (results.size() <= limit) {
+                break;
+            }
+
+            var lastEvent = page.getLast();
+            cursor = new Cursor(lastEvent.startTime(), lastEvent.id());
+        }
+
+        assertThat(allIds)
+                .as("All 7 events should appear exactly once in descending pagination")
+                .hasSize(7)
+                .doesNotHaveDuplicates();
+
+        assertThat(new HashSet<>(allIds))
+                .containsExactlyInAnyOrder(
+                        "evt-a", "evt-b", "evt-c", "evt-d", "evt-e", "evt-f", "evt-g");
+    }
+
+    @Test
+    @DisplayName("descending cursor skips past the cursor position")
+    void descendingCursorSkipsPastPosition() {
+        var firstPage = store.query(T1, T3, 3, null, Event.START_TIME_DESC);
+        var lastEvent = firstPage.getLast();
+
+        var cursor = new Cursor(lastEvent.startTime(), lastEvent.id());
+        var secondPage = store.query(T1, T3, 3, cursor, Event.START_TIME_DESC);
+
+        assertThat(secondPage).isNotEmpty();
+        // All second-page events should come after the cursor in descending order
+        assertThat(secondPage)
+                .allSatisfy(event ->
+                        assertThat(Event.START_TIME_DESC.compare(event, lastEvent))
+                                .isGreaterThan(0));
+    }
+
+    @Test
+    @DisplayName("descending narrow range returns only matching events")
+    void descendingNarrowRangeReturnsSubset() {
+        var results = store.query(T2, T2, 100, null, Event.START_TIME_DESC);
+
+        assertThat(results)
+                .hasSize(3)
+                .allSatisfy(event -> assertThat(event.startTime()).isEqualTo(T2));
+    }
 }


### PR DESCRIPTION
## Summary
- **Configurable sort order** — `direction=asc|desc` param, cursor derived from same ordering (#11)
- **Payload substring filter** — `payload_contains` param, case-insensitive, consistent paginated totals (#12)
- **OpenAPI / Swagger UI** — interactive docs at `/swagger-ui.html`, spec at `/v3/api-docs` (#13)

## Changes
- `Event`: added `START_TIME_DESC` comparator and `comparatorForDirection()`
- `EventStore`: added `sortOrder` and `payloadContains` params with default methods for backward compat
- `InMemoryEventStore`: ascending + descending views, filter applied before pagination
- `EventController`: OpenAPI annotations, new query params
- **18 new tests** (50 total, all passing)

## Test plan
- [x] All 50 tests pass (`./mvnw test`)
- [x] Descending pagination: no dupes, no missing IDs, totals match ascending
- [x] Filtered pagination: totals match non-paginated filtered query
- [x] Various limit sizes tested with both directions
- [x] Invalid direction returns 400
- [ ] Manual: verify Swagger UI renders at `/swagger-ui.html`

Closes #11, closes #12, closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `direction` (asc/desc, default asc) and `payload_contains` query params for GET /api/events; invalid `direction` returns HTTP 400
  * Interactive API docs (Swagger/OpenAPI UI) and generated Javadoc exposed from the running app

* **Behavior**
  * Sorting by start_time then id; `direction=desc` reverses order and cursor must match sort direction
  * Filtering (`payload_contains`) is applied before pagination

* **Documentation**
  * Expanded README with Maven wrapper usage, endpoints, docs locations, sorting/filtering semantics, and error details

* **Tests**
  * Test totals updated (32 → 50); new unit/integration tests for sorting, pagination, and filtering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->