### PR TITLE
Add Postman collection and API client generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,35 @@ curl "http://localhost:8080/api/events?start_time=1708646400&end_time=1710028800
 | 400    | Invalid or malformed `cursor`              |
 | 400    | Invalid `direction` (not `asc` or `desc`)  |
 
+### Postman Collection
+
+A ready-to-use Postman collection is included in the repo. Import it to explore every endpoint scenario without writing a single request by hand.
+
+```
+postman/
+  events-api.postman_collection.json    # 16 requests across 5 folders
+  local.postman_environment.json        # {{base_url}}, {{start_time}}, {{end_time}}, {{next_cursor}}
+```
+
+**Quick start:**
+
+1. Start the server: `./mvnw spring-boot:run`
+2. In Postman: **File → Import** → select both files from the `postman/` folder
+3. Select the **Events API — Local** environment (top-right dropdown)
+4. Run any request, or use the **Collection Runner** on the "Pagination Walk" folder to page through all 34 events automatically
+
+**What's included:**
+
+| Folder | Requests | What it tests |
+|--------|----------|---------------|
+| Happy Path | 3 | Default limit, single-page fetch, small pages |
+| Pagination Walk | 4 | Sequential page-through (auto-captures `next_cursor` between requests) |
+| Sorting | 2 | Ascending vs descending order |
+| Filtering | 3 | Payload substring, no matches, combined filter + sort |
+| Edge Cases & Errors | 6 | Empty range, limit=1, missing params (400), invalid cursor (400), invalid direction (400) |
+
+Each request in the Pagination Walk and Edge Cases folders includes **test scripts** that validate status codes, array sizes, and cursor presence — so the Collection Runner gives you a green/red pass/fail summary.
+
 ### Interactive API Docs
 
 When the server is running, Swagger UI is available at:

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ These are not required. The core assignment is date range + cursor-based paginat
 
 # Clean build artifacts
 ./mvnw clean
+
+# Generate API clients (Java, Python, TypeScript)
+./mvnw generate-sources -Pclient-java
+./mvnw generate-sources -Pclient-python
+./mvnw generate-sources -Pclient-typescript
 ```
 
 ### Docker
@@ -250,6 +255,26 @@ postman/
 | Edge Cases & Errors | 6 | Empty range, limit=1, missing params (400), invalid cursor (400), invalid direction (400) |
 
 Each request in the Pagination Walk and Edge Cases folders includes **test scripts** that validate status codes, array sizes, and cursor presence — so the Collection Runner gives you a green/red pass/fail summary.
+
+### Generated API Clients
+
+The OpenAPI spec (`openapi/events-api.json`) powers auto-generated clients in multiple languages via the [OpenAPI Generator](https://openapi-generator.tech/) Maven plugin. No extra installs required — just run a profile:
+
+```bash
+# Generate a Java client (java.net.http, Jakarta EE)
+./mvnw generate-sources -Pclient-java
+# → target/generated-clients/java/
+
+# Generate a Python client
+./mvnw generate-sources -Pclient-python
+# → target/generated-clients/python/
+
+# Generate a TypeScript client (fetch-based)
+./mvnw generate-sources -Pclient-typescript
+# → target/generated-clients/typescript/
+```
+
+Each generated client includes models (`Event`, `EventPageResponse`), an API class with the `getEvents` method fully typed, and a README with usage instructions. The spec file is committed to the repo so clients can be generated without running the server.
 
 ### Interactive API Docs
 

--- a/openapi/events-api.json
+++ b/openapi/events-api.json
@@ -1,0 +1,180 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Events API",
+        "description": "Cursor-based paginated events API for querying events within a date range.",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8080",
+            "description": "Local development server"
+        }
+    ],
+    "tags": [
+        {
+            "name": "Events",
+            "description": "Cursor-based paginated events API"
+        }
+    ],
+    "paths": {
+        "/api/events": {
+            "get": {
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Query events by date range with cursor-based pagination",
+                "description": "Returns events whose start_time falls within [start_time, end_time] inclusive.\nResults are paginated using an opaque cursor. Pass next_cursor from a previous\nresponse to fetch the next page. Pagination is complete when next_cursor is null.\n\nImportant: a cursor is only valid when reused with the same query parameters\nthat produced it (start_time, end_time, direction, payload_contains). Changing\nany of these between pages alters the result stream and may cause the cursor\nto resume from an incorrect position.",
+                "operationId": "getEvents",
+                "parameters": [
+                    {
+                        "name": "start_time",
+                        "in": "query",
+                        "description": "Start of date range (inclusive, Unix seconds)",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "example": 1708646400
+                    },
+                    {
+                        "name": "end_time",
+                        "in": "query",
+                        "description": "End of date range (inclusive, Unix seconds)",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "example": 1710028800
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max events per page (default 20, max 100)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "example": 10
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "description": "Opaque cursor from a previous next_cursor. Only valid with the same start_time, end_time, direction, and payload_contains that produced it.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "direction",
+                        "in": "query",
+                        "description": "Sort direction: asc (default) or desc",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "example": "asc"
+                    },
+                    {
+                        "name": "payload_contains",
+                        "in": "query",
+                        "description": "Case-insensitive substring filter on event payload",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "Jazz"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Page of events",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EventPageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters or cursor",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "description": "Human-readable error message"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Event": {
+                "type": "object",
+                "properties": {
+                    "start_time": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Unix timestamp in seconds for the event start",
+                        "example": 1708646400
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique logical event identifier",
+                        "example": "evt-a1"
+                    },
+                    "payload": {
+                        "type": "string",
+                        "description": "Human-readable event description",
+                        "example": "Blue Note - Live Jazz"
+                    }
+                },
+                "required": [
+                    "start_time",
+                    "id",
+                    "payload"
+                ]
+            },
+            "EventPageResponse": {
+                "type": "object",
+                "properties": {
+                    "events": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Event"
+                        },
+                        "description": "Array of events for the current page"
+                    },
+                    "next_cursor": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Opaque cursor for the next page, or null when this is the last page"
+                    }
+                },
+                "required": [
+                    "events",
+                    "next_cursor"
+                ]
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,4 +67,91 @@
 		</plugins>
 	</build>
 
+	<!--
+	  Client generation profiles: generate API clients from the OpenAPI spec.
+	  Usage: ./mvnw generate-sources -Pclient-java
+	         ./mvnw generate-sources -Pclient-python
+	         ./mvnw generate-sources -Pclient-typescript
+	  Output: target/generated-clients/<language>/
+	-->
+	<profiles>
+		<profile>
+			<id>client-java</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.openapitools</groupId>
+						<artifactId>openapi-generator-maven-plugin</artifactId>
+						<version>7.12.0</version>
+						<executions>
+							<execution>
+								<goals><goal>generate</goal></goals>
+								<configuration>
+									<inputSpec>${project.basedir}/openapi/events-api.json</inputSpec>
+									<generatorName>java</generatorName>
+									<output>${project.build.directory}/generated-clients/java</output>
+									<apiPackage>io.github.mattmck.events.client.api</apiPackage>
+									<modelPackage>io.github.mattmck.events.client.model</modelPackage>
+									<configOptions>
+										<library>native</library>
+										<useJakartaEe>true</useJakartaEe>
+									</configOptions>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>client-python</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.openapitools</groupId>
+						<artifactId>openapi-generator-maven-plugin</artifactId>
+						<version>7.12.0</version>
+						<executions>
+							<execution>
+								<goals><goal>generate</goal></goals>
+								<configuration>
+									<inputSpec>${project.basedir}/openapi/events-api.json</inputSpec>
+									<generatorName>python</generatorName>
+									<output>${project.build.directory}/generated-clients/python</output>
+									<configOptions>
+										<packageName>events_client</packageName>
+									</configOptions>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>client-typescript</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.openapitools</groupId>
+						<artifactId>openapi-generator-maven-plugin</artifactId>
+						<version>7.12.0</version>
+						<executions>
+							<execution>
+								<goals><goal>generate</goal></goals>
+								<configuration>
+									<inputSpec>${project.basedir}/openapi/events-api.json</inputSpec>
+									<generatorName>typescript-fetch</generatorName>
+									<output>${project.build.directory}/generated-clients/typescript</output>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>

--- a/postman/events-api.postman_collection.json
+++ b/postman/events-api.postman_collection.json
@@ -1,0 +1,585 @@
+{
+  "info": {
+    "_postman_id": "events-api-collection",
+    "name": "Events API — Cursor-Based Pagination",
+    "description": "Postman collection for the Events API take-home assessment.\n\nStart the server with `./mvnw spring-boot:run`, select the **Events API — Local** environment, then run any request.\n\nThe **Pagination Walk** folder auto-captures `next_cursor` from each response so you can click through pages sequentially.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Happy Path",
+      "item": [
+        {
+          "name": "All events (default limit)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" }
+              ]
+            },
+            "description": "Returns up to 20 events (default limit) across the full sample data range. Expect 20 events and a non-null `next_cursor`."
+          }
+        },
+        {
+          "name": "All events (limit=100, single page)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&limit=100",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "limit", "value": "100" }
+              ]
+            },
+            "description": "With limit=100, all 34 unique events fit on one page. Expect `next_cursor` to be `null`."
+          }
+        },
+        {
+          "name": "Small page (limit=5)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "if (jsonData.next_cursor) {",
+                  "    pm.environment.set('next_cursor', jsonData.next_cursor);",
+                  "}",
+                  "",
+                  "pm.test('Returns 5 events', function () {",
+                  "    pm.expect(jsonData.events.length).to.eql(5);",
+                  "});",
+                  "",
+                  "pm.test('Has next_cursor', function () {",
+                  "    pm.expect(jsonData.next_cursor).to.not.be.null;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&limit=5",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "limit", "value": "5" }
+              ]
+            },
+            "description": "Returns 5 events with a `next_cursor`. Also saves `next_cursor` to the environment variable for follow-up requests."
+          }
+        }
+      ],
+      "description": "Basic queries demonstrating the API works end-to-end."
+    },
+    {
+      "name": "Pagination Walk",
+      "item": [
+        {
+          "name": "Page 1 (start fresh, limit=10)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Returns 10 events', function () {",
+                  "    pm.expect(jsonData.events.length).to.eql(10);",
+                  "});",
+                  "",
+                  "pm.test('Has next_cursor', function () {",
+                  "    pm.expect(jsonData.next_cursor).to.not.be.null;",
+                  "});",
+                  "",
+                  "if (jsonData.next_cursor) {",
+                  "    pm.environment.set('next_cursor', jsonData.next_cursor);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&limit=10",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "limit", "value": "10" }
+              ]
+            },
+            "description": "First page — 10 events. Saves `next_cursor` to the environment."
+          }
+        },
+        {
+          "name": "Page 2 (auto-cursor)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Returns 10 events', function () {",
+                  "    pm.expect(jsonData.events.length).to.eql(10);",
+                  "});",
+                  "",
+                  "pm.test('Has next_cursor', function () {",
+                  "    pm.expect(jsonData.next_cursor).to.not.be.null;",
+                  "});",
+                  "",
+                  "if (jsonData.next_cursor) {",
+                  "    pm.environment.set('next_cursor', jsonData.next_cursor);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&limit=10&cursor={{next_cursor}}",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "limit", "value": "10" },
+                { "key": "cursor", "value": "{{next_cursor}}" }
+              ]
+            },
+            "description": "Second page — uses `next_cursor` saved from Page 1."
+          }
+        },
+        {
+          "name": "Page 3 (auto-cursor)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Returns 10 events', function () {",
+                  "    pm.expect(jsonData.events.length).to.eql(10);",
+                  "});",
+                  "",
+                  "pm.test('Has next_cursor', function () {",
+                  "    pm.expect(jsonData.next_cursor).to.not.be.null;",
+                  "});",
+                  "",
+                  "if (jsonData.next_cursor) {",
+                  "    pm.environment.set('next_cursor', jsonData.next_cursor);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&limit=10&cursor={{next_cursor}}",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "limit", "value": "10" },
+                { "key": "cursor", "value": "{{next_cursor}}" }
+              ]
+            },
+            "description": "Third page — uses `next_cursor` saved from Page 2."
+          }
+        },
+        {
+          "name": "Page 4 — last page (auto-cursor)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Returns 4 events (remainder)', function () {",
+                  "    pm.expect(jsonData.events.length).to.eql(4);",
+                  "});",
+                  "",
+                  "pm.test('next_cursor is null (last page)', function () {",
+                  "    pm.expect(jsonData.next_cursor).to.be.null;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&limit=10&cursor={{next_cursor}}",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "limit", "value": "10" },
+                { "key": "cursor", "value": "{{next_cursor}}" }
+              ]
+            },
+            "description": "Last page — 4 remaining events, `next_cursor` is `null`. Total across all pages: 10 + 10 + 10 + 4 = 34 unique events."
+          }
+        }
+      ],
+      "description": "Walk through all 34 events in 4 pages (limit=10). Each request auto-saves `next_cursor` to the environment so the next request picks it up.\n\nRun these **sequentially** (Page 1 → 2 → 3 → 4) or use the Postman Collection Runner."
+    },
+    {
+      "name": "Sorting",
+      "item": [
+        {
+          "name": "Ascending (default)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&limit=5&direction=asc",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "limit", "value": "5" },
+                { "key": "direction", "value": "asc" }
+              ]
+            },
+            "description": "Earliest events first (default). Compare `start_time` values — they should increase."
+          }
+        },
+        {
+          "name": "Descending",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&limit=5&direction=desc",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "limit", "value": "5" },
+                { "key": "direction", "value": "desc" }
+              ]
+            },
+            "description": "Most recent events first. Compare `start_time` values — they should decrease."
+          }
+        }
+      ],
+      "description": "Verify ascending and descending sort order."
+    },
+    {
+      "name": "Filtering",
+      "item": [
+        {
+          "name": "Filter by payload substring",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&payload_contains=Jazz",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "payload_contains", "value": "Jazz" }
+              ]
+            },
+            "description": "Only events whose payload contains \"Jazz\" (case-insensitive)."
+          }
+        },
+        {
+          "name": "Filter with no matches",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&payload_contains=ZZZZZ",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "payload_contains", "value": "ZZZZZ" }
+              ]
+            },
+            "description": "No events match. Expect an empty `events` array and `next_cursor: null`."
+          }
+        },
+        {
+          "name": "Filter + descending sort",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&payload_contains=Jazz&direction=desc&limit=5",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "payload_contains", "value": "Jazz" },
+                { "key": "direction", "value": "desc" },
+                { "key": "limit", "value": "5" }
+              ]
+            },
+            "description": "Combined: filter by payload + descending sort."
+          }
+        }
+      ],
+      "description": "Payload substring filter (case-insensitive). Verify that filtered results are consistent."
+    },
+    {
+      "name": "Edge Cases & Errors",
+      "item": [
+        {
+          "name": "Empty date range",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test('Status is 200', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('Events array is empty', function () {",
+                  "    pm.expect(jsonData.events.length).to.eql(0);",
+                  "});",
+                  "",
+                  "pm.test('next_cursor is null', function () {",
+                  "    pm.expect(jsonData.next_cursor).to.be.null;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time=9999999999&end_time=9999999999",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "9999999999" },
+                { "key": "end_time", "value": "9999999999" }
+              ]
+            },
+            "description": "A date range with no events. Expect empty array and null cursor."
+          }
+        },
+        {
+          "name": "Limit = 1 (smallest page)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test('Returns exactly 1 event', function () {",
+                  "    pm.expect(jsonData.events.length).to.eql(1);",
+                  "});",
+                  "",
+                  "pm.test('Has next_cursor', function () {",
+                  "    pm.expect(jsonData.next_cursor).to.not.be.null;",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&limit=1",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "limit", "value": "1" }
+              ]
+            },
+            "description": "Smallest possible page. Should return 1 event and a cursor."
+          }
+        },
+        {
+          "name": "400 — Missing start_time",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 400', function () {",
+                  "    pm.response.to.have.status(400);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?end_time={{end_time}}",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "end_time", "value": "{{end_time}}" }
+              ]
+            },
+            "description": "Missing required `start_time`. Expect 400."
+          }
+        },
+        {
+          "name": "400 — Missing end_time",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 400', function () {",
+                  "    pm.response.to.have.status(400);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" }
+              ]
+            },
+            "description": "Missing required `end_time`. Expect 400."
+          }
+        },
+        {
+          "name": "400 — Invalid cursor",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 400', function () {",
+                  "    pm.response.to.have.status(400);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&cursor=not-a-valid-cursor!!",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "cursor", "value": "not-a-valid-cursor!!" }
+              ]
+            },
+            "description": "Malformed cursor. Expect 400 with error message."
+          }
+        },
+        {
+          "name": "400 — Invalid direction",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 400', function () {",
+                  "    pm.response.to.have.status(400);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/events?start_time={{start_time}}&end_time={{end_time}}&direction=sideways",
+              "host": ["{{base_url}}"],
+              "path": ["api", "events"],
+              "query": [
+                { "key": "start_time", "value": "{{start_time}}" },
+                { "key": "end_time", "value": "{{end_time}}" },
+                { "key": "direction", "value": "sideways" }
+              ]
+            },
+            "description": "Invalid sort direction. Expect 400."
+          }
+        }
+      ],
+      "description": "Boundary conditions and error handling. Each request includes a test script that verifies the expected status code."
+    }
+  ]
+}

--- a/postman/local.postman_environment.json
+++ b/postman/local.postman_environment.json
@@ -1,0 +1,31 @@
+{
+  "id": "events-local-env",
+  "name": "Events API — Local",
+  "values": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:8080",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "start_time",
+      "value": "1708646400",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "end_time",
+      "value": "1710028800",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "next_cursor",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment"
+}


### PR DESCRIPTION
## Summary
- **Postman collection** (`postman/`) — 16 requests across 5 folders with test scripts for the Collection Runner
- **OpenAPI client generation** — Maven profiles for Java, Python, and TypeScript via `openapi-generator-maven-plugin`
- **Static OpenAPI spec** (`openapi/events-api.json`) — corrected to match snake_case wire format

## Maven Targets

```bash
./mvnw generate-sources -Pclient-java
./mvnw generate-sources -Pclient-python
./mvnw generate-sources -Pclient-typescript
```

## Test plan
- [x] All 50 tests pass
- [x] All three client profiles generate successfully
- [x] Postman collection imports cleanly (tested locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API specification for the Events API with cursor-based pagination support, filtering, and sorting capabilities.
  * Introduced automated API client generation for Java, Python, and TypeScript.

* **Documentation**
  * Updated documentation with Postman collection for API testing and validation.
  * Added generated API client configuration and output directory information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->